### PR TITLE
chore: configure issue tracker, PR defaults, and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,21 @@
 ## Summary
 
+### Context
+
+<!-- Describe the problem or background: what is the issue, why does it exist, and what impact does it have? -->
+
+### Changes
+
+<!-- Describe what was changed and explain why those changes solve the issue described above -->
+
 ## Breaking Changes
+
 <!-- Delete this section if there are no breaking changes -->
 
 ## Test Plan
+
 <!-- Add steps a reviewer can follow to verify your changes -->
+
 - [ ]
 
 Refs: #

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent configuration
+
+## Issue tracker
+
+This repo uses GitHub Issues and GitHub Project #7 ("D&D Mapp") for issue tracking. For configuration, see [issue-tracker.md](docs/agents/issue-tracker.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,7 @@
 ## Issue tracker
 
 This repo uses GitHub Issues and GitHub Project #7 ("D&D Mapp") for issue tracking. For configuration, see [issue-tracker.md](docs/agents/issue-tracker.md).
+
+## Pull requests
+
+This repo uses GitHub for pull requests. For configuration, see [docs/agents/pull-requests.md](docs/agents/pull-requests.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude instructions
+
+For agent instructions and repo-specific configuration, see [AGENTS.md](AGENTS.md).

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,28 @@
+# Issue Tracker
+
+## Tracker Backend
+
+github-issues-projects
+
+## GitHub
+
+- **Repo:** `dnd-mapp/.github`
+- **Org:** `dnd-mapp`
+- **Project:** `#7` — "D&D Mapp" (`PVT_kwDODFcis84BY-C4`)
+
+## Issue Types
+
+Configured as GitHub org-level issue types. For full definitions, see [issue-types.md](issue-types.md).
+
+## Field representation
+
+Fields are stored in two places:
+
+- **Org-level issue fields** — set on the GitHub Issue itself (Priority, Severity, Story Points, Time Box)
+- **Project fields** — set on the Project item (Status, Target Quarter, Parent issue)
+
+## Linking conventions
+
+- `Parent #<n>` — parent reference
+- `Closes #<n>` — resolution reference
+- `Refs #<n>` — related reference

--- a/docs/agents/issue-types.md
+++ b/docs/agents/issue-types.md
@@ -1,0 +1,216 @@
+# Issue Types
+
+## Epic
+
+**Hierarchy:** can contain Stories and Spikes
+
+### Issue Type
+
+Org-level issue type: `Epic` (node ID: `IT_kwDODFcis84CBKdR`)
+
+### Fields
+
+| Field       | Kind                  | Node ID                         | Type          | Values / format               |
+|:------------|:----------------------|:--------------------------------|:--------------|:------------------------------|
+| `priority`  | Org-level issue field | `IFSS_kgDOAopeGg`               | Single-select | P0 \| P1 \| P2 \| P3          |
+| `iteration` | Project field         | `PVTIF_lADODFcis84BY-C4zhUBQBo` | Iteration     | Q2 2026 \| Q3 2026 \| Q4 2026 |
+
+**Priority options** (org-level issue field `IFSS_kgDOAopeGg`):
+
+| Value | ID         | Description                                                 |
+|:------|:-----------|:------------------------------------------------------------|
+| `P0`  | `74587961` | Drop everything — blocking critical path or a live incident |
+| `P1`  | `74587962` | High priority — must be addressed this quarter              |
+| `P2`  | `74587963` | Normal priority — planned and scheduled                     |
+| `P3`  | `74587964` | Low priority — nice to have, no firm commitment             |
+
+### Statuses
+
+`Status` Project field (single-select, node ID: `PVTSSF_lADODFcis84BY-C4zhUADuc`):
+
+| Status        | Option ID  |
+|:--------------|:-----------|
+| `backlog`     | `f75ad846` |
+| `in-progress` | `0d8b05a3` |
+| `done`        | `8f8e8157` |
+
+### Body template
+
+```md
+## Goal
+
+## Scope
+
+## Out of scope
+```
+
+---
+
+## Story
+
+**Hierarchy:** child of Epic
+
+### Issue Type
+
+Org-level issue type: `Story` (node ID: `IT_kwDODFcis84CBKrx`)
+
+### Fields
+
+| Field        | Kind                   | Node ID                        | Type          | Values / format             |
+|:-------------|:-----------------------|:-------------------------------|:--------------|:----------------------------|
+| `priority`   | Org-level issue field  | `IFSS_kgDOAopeGg`              | Single-select | P0 \| P1 \| P2 \| P3        |
+| `estimation` | Org-level issue field  | `IFN_kgDOAoptyA`               | Number        | 1 \| 2 \| 3 \| 5 \| 8 \| 13 |
+| `parent`     | Project field (native) | `PVTF_lADODFcis84BY-C4zhUADu4` | Parent issue  | `Parent #<n>`               |
+
+**Priority options:** see Epic section above.
+
+### Statuses
+
+`Status` Project field (single-select, node ID: `PVTSSF_lADODFcis84BY-C4zhUADuc`):
+
+| Status        | Option ID  |
+|:--------------|:-----------|
+| `backlog`     | `f75ad846` |
+| `ready`       | `6479c4dc` |
+| `in-progress` | `0d8b05a3` |
+| `in-review`   | `441688e8` |
+| `done`        | `8f8e8157` |
+
+### Body template
+
+```md
+## User Story
+
+As a [persona], I want [goal], so that [reason].
+
+## Acceptance criteria
+
+- [ ]
+- [ ]
+```
+
+---
+
+## Task
+
+**Hierarchy:** child of Story
+
+### Issue Type
+
+Org-level issue type: `Task` (node ID: `IT_kwDODFcis84CBKxI`)
+
+### Fields
+
+| Field    | Kind                   | Node ID                        | Type         | Values / format |
+|:---------|:-----------------------|:-------------------------------|:-------------|:----------------|
+| `parent` | Project field (native) | `PVTF_lADODFcis84BY-C4zhUADu4` | Parent issue | `Parent #<n>`   |
+
+### Statuses
+
+`Status` Project field (single-select, node ID: `PVTSSF_lADODFcis84BY-C4zhUADuc`):
+
+| Status        | Option ID  |
+|:--------------|:-----------|
+| `backlog`     | `f75ad846` |
+| `in-progress` | `0d8b05a3` |
+| `in-review`   | `441688e8` |
+| `done`        | `8f8e8157` |
+
+### Body template
+
+```md
+## Description
+```
+
+---
+
+## Bug
+
+**Hierarchy:** standalone
+
+### Issue Type
+
+Org-level issue type: `Bug` (node ID: `IT_kwDODFcis84CBK3a`)
+
+### Fields
+
+| Field      | Kind                  | Node ID           | Type          | Values / format      |
+|:-----------|:----------------------|:------------------|:--------------|:---------------------|
+| `priority` | Org-level issue field | `IFSS_kgDOAopeGg` | Single-select | P0 \| P1 \| P2 \| P3 |
+| `severity` | Org-level issue field | `IFSS_kgDOAoplog` | Single-select | S0 \| S1 \| S2 \| S3 |
+
+**Priority options:** see Epic section above.
+
+**Severity options** (org-level issue field `IFSS_kgDOAoplog`):
+
+| Value | ID         | Description                                                           |
+|:------|:-----------|:----------------------------------------------------------------------|
+| `S0`  | `74591344` | Data loss, corruption, or complete feature failure with no workaround |
+| `S1`  | `74591345` | Core flow broken; workaround exists but is painful                    |
+| `S2`  | `74591346` | Degraded experience; reasonable workaround available                  |
+| `S3`  | `74591347` | Cosmetic or minor issue; does not impact functionality                |
+
+### Statuses
+
+`Status` Project field (single-select, node ID: `PVTSSF_lADODFcis84BY-C4zhUADuc`):
+
+| Status        | Option ID  |
+|:--------------|:-----------|
+| `backlog`     | `f75ad846` |
+| `ready`       | `6479c4dc` |
+| `in-progress` | `0d8b05a3` |
+| `in-review`   | `441688e8` |
+| `done`        | `8f8e8157` |
+
+### Body template
+
+```md
+## Steps to reproduce
+
+## Expected
+
+## Actual
+
+## Environment
+```
+
+---
+
+## Spike
+
+**Hierarchy:** standalone or child of Epic
+
+### Issue Type
+
+Org-level issue type: `Spike` (node ID: `IT_kwDODFcis84CBK-7`)
+
+### Fields
+
+| Field      | Kind                   | Node ID                        | Type          | Values / format                      |
+|:-----------|:-----------------------|:-------------------------------|:--------------|:-------------------------------------|
+| `priority` | Org-level issue field  | `IFSS_kgDOAopeGg`              | Single-select | P0 \| P1 \| P2 \| P3                 |
+| `time-box` | Org-level issue field  | `IFT_kgDOAopn2A`               | Text          | Days allocated (e.g. `2d`, `1 week`) |
+| `parent`   | Project field (native) | `PVTF_lADODFcis84BY-C4zhUADu4` | Parent issue  | `Parent #<n>`                        |
+
+**Priority options:** see Epic section above.
+
+### Statuses
+
+`Status` Project field (single-select, node ID: `PVTSSF_lADODFcis84BY-C4zhUADuc`):
+
+| Status        | Option ID  |
+|:--------------|:-----------|
+| `backlog`     | `f75ad846` |
+| `ready`       | `6479c4dc` |
+| `in-progress` | `0d8b05a3` |
+| `done`        | `8f8e8157` |
+
+### Body template
+
+```md
+## Goal
+
+## Time box
+
+## Findings
+```

--- a/docs/agents/pull-requests.md
+++ b/docs/agents/pull-requests.md
@@ -1,0 +1,17 @@
+# Pull Requests
+
+## Target branch
+
+main
+
+## Direct push to target branch
+
+not allowed
+
+## Draft by default
+
+false
+
+## PR template
+
+.github/PULL_REQUEST_TEMPLATE.md (repo-level)


### PR DESCRIPTION
## Summary

### Context

This repo had no agent configuration or PR template subsections. Issue tracking, pull request defaults, and the PR template were unconfigured, leaving agents without the context needed to create well-formed issues and PRs.

### Changes

- Added `Context` and `Changes` subsections to the PR template Summary section so authors explain the problem and the solution separately.
- Wired up GitHub Issues + Project #7 ("D&D Mapp") as the issue tracker backend, matching the `agent-skills` sibling repo configuration (same org-level Issue Types and fields).
- Added `docs/agents/pull-requests.md` with PR defaults (target: `main`, no direct push, no draft-by-default, repo-level template).
- Added `CLAUDE.md` and updated `AGENTS.md` with pointers to all agent config.

## Test Plan

- [x] Verify `.github/PULL_REQUEST_TEMPLATE.md` renders the two subsections correctly on a new PR
- [x] Verify agents can read `docs/agents/issue-tracker.md` and `docs/agents/pull-requests.md`